### PR TITLE
fix: use gpg passphrase secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.PASSPHRASE }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,8 +45,6 @@ signs:
       # if you are using this in a GitHub action or some other automated pipeline, you
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
-      - "--pinentry-mode"
-      - "loopback"
       - "--local-user"
       - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
       - "--output"


### PR DESCRIPTION
- rename secrets for naming consistency reasons
- revert last commit, which was aiming to solve a problem; whereas the root cause was a wrongly named secret

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release pipeline configuration for GPG signing: changed passphrase secret reference and removed interactive pinentry flags so automated signing uses non-interactive passphrase handling. This streamlines automated signing and reduces prompts during build/release runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->