### PR TITLE
fix: add timeouts and early failure detection for VM provisioning

### DIFF
--- a/internal/provider/virtual_machine_resource.go
+++ b/internal/provider/virtual_machine_resource.go
@@ -293,10 +293,10 @@ func (r *virtualMachineResource) Create(ctx context.Context, req resource.Create
 		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	}
 
-	// The provisioning timeout is generous here, as usually the VM is provisioned
-	// within 2 - 6 mins. The timeout here is in case of failure so that we eventually
-	// exit and don't wait for the VM infinitely.
-	provisioningTimeout := time.After(28 * time.Minute)
+	// The provisioning timeout covers the case where the VM never reaches a
+	// terminal state (e.g. stuck Initializing due to capacity issues).
+	// Typical provisioning completes in 2-6 minutes.
+	provisioningTimeout := time.After(5 * time.Minute)
 
 	// We have successfully rented out the VM. Poll until finished creating, or timeout is reached.
 	for {
@@ -333,6 +333,30 @@ func (r *virtualMachineResource) Create(ctx context.Context, req resource.Create
 			}
 
 			last = current
+
+			// Fail fast if the instance entered a terminal non-success state.
+			// This avoids waiting for the full timeout when the VM cannot be provisioned.
+			// Note: Inactive is not checked here because GetInstance already
+			// converts it to ErrNotFound, which is handled above.
+			if last.Status == cloudriftapi.Deactivating {
+				savePartialState()
+				resp.Diagnostics.AddError(
+					"Virtual Machine provisioning failed",
+					fmt.Sprintf("Instance %s reached terminal status %q instead of becoming active", id, last.Status),
+				)
+				return
+			}
+
+			// Fail fast if the underlying node is unhealthy.
+			switch last.NodeStatus {
+			case cloudriftapi.Offline, cloudriftapi.NotResponding, cloudriftapi.Hibernated:
+				savePartialState()
+				resp.Diagnostics.AddError(
+					"Virtual Machine provisioning failed",
+					fmt.Sprintf("Instance %s node is %q — VM cannot be provisioned on an unhealthy node", id, last.NodeStatus),
+				)
+				return
+			}
 
 			// Currently it is only one VM per instance, while the [Status] field
 			// tells us that the Instance is spawned successfully, it does not tell us
@@ -415,8 +439,17 @@ func (r *virtualMachineResource) Delete(ctx context.Context, req resource.Delete
 		return
 	}
 
+	destructionTimeout := time.After(5 * time.Minute)
+
 	for {
 		select {
+		case <-destructionTimeout:
+			resp.Diagnostics.AddError(
+				"Destruction timeout reached",
+				"Destruction timeout reached before finished waiting on instance deletion for ID: "+state.ID.ValueString(),
+			)
+			return
+
 		case <-ctx.Done():
 			// Context cancelled.
 			//
@@ -430,10 +463,11 @@ func (r *virtualMachineResource) Delete(ctx context.Context, req resource.Delete
 			}
 			return
 		case <-time.After(InstancePollingInterval):
-			// wait until the Instance is no longer returned by the CloudRift API.
+			// Wait until the Instance is gone.
+			// GetInstance returns ErrNotFound once the instance reaches Inactive.
 			if _, err := r.client.GetInstance(state.ID.ValueString()); err != nil {
 				if errors.Is(err, cloudriftapi.ErrNotFound) {
-					// successfully destroyed.
+					// Successfully destroyed.
 					return
 				}
 				resp.Diagnostics.AddError(

--- a/internal/provider/virtual_machine_resource_test.go
+++ b/internal/provider/virtual_machine_resource_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -87,6 +88,140 @@ func Test_VirtualMachineResrouce(t *testing.T) {
 				`, keyName, publicKey),
 			},
 		},
+	})
+}
+
+func Test_VirtualMachineResource_FailsOnInactiveStatus(t *testing.T) {
+	t.Parallel()
+
+	keyName := "anotheruser-key"
+	publicKey := "ssh-rsa AAAA anotheruser"
+
+	// Simulate a VM that goes Inactive after rent (e.g. no capacity).
+	// Note: GetInstance converts Inactive to ErrNotFound at the client level,
+	// so the provider sees a "resource not found" error rather than the status.
+	server := newVMTestServerWithStatus(keyName, publicKey, "Inactive", false)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig(server.URL, "1.0") + fmt.Sprintf(`
+					resource "cloudrift_ssh_key" "primary" {
+					  name       = "%s"
+					  public_key = "%s"
+					}
+
+					resource "cloudrift_virtual_machine" "machine0" {
+					  recipe        = "ubuntu"
+					  datacenter    = "us-east-nc-nr-1"
+					  instance_type = "rtx49-10c-kn.1"
+					  ssh_key_id    = cloudrift_ssh_key.primary.id
+					}
+				`, keyName, publicKey),
+				ExpectError: regexp.MustCompile(`failed to poll status`),
+			},
+		},
+	})
+}
+
+func Test_VirtualMachineResource_FailsOnDeactivatingStatus(t *testing.T) {
+	t.Parallel()
+
+	keyName := "anotheruser-key"
+	publicKey := "ssh-rsa AAAA anotheruser"
+
+	// Simulate a VM that goes Deactivating after rent.
+	server := newVMTestServerWithStatus(keyName, publicKey, "Deactivating", false)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig(server.URL, "1.0") + fmt.Sprintf(`
+					resource "cloudrift_ssh_key" "primary" {
+					  name       = "%s"
+					  public_key = "%s"
+					}
+
+					resource "cloudrift_virtual_machine" "machine0" {
+					  recipe        = "ubuntu"
+					  datacenter    = "us-east-nc-nr-1"
+					  instance_type = "rtx49-10c-kn.1"
+					  ssh_key_id    = cloudrift_ssh_key.primary.id
+					}
+				`, keyName, publicKey),
+				ExpectError: regexp.MustCompile(`reached terminal status "Deactivating"`),
+			},
+		},
+	})
+}
+
+// newVMTestServerWithStatus creates a test server where the instance reports
+// the given status and VM readiness. After terminate is called, the instance
+// list returns empty so the test framework's destroy cleanup completes.
+func newVMTestServerWithStatus(keyName, publicKey, status string, vmReady bool) *httptest.Server {
+	terminated := false
+
+	instanceResponse := fmt.Sprintf(`
+	{
+		"data": {
+			"instances": [
+				{
+					"id": "1",
+					"node_id": "1",
+					"node_mode": "Virtual Machine",
+					"node_status": "Ready",
+					"host_address": "127.0.0.1",
+					"internal_host_address": "10.0.0.1",
+					"resource_info": {
+						"provider_name": "provider",
+						"instance_type": "rtx49-10c-kn.1"
+					},
+					"virtual_machines": [
+						{
+							"vmid": 100,
+							"name": "vm-1",
+							"ready": %v
+						}
+					],
+					"status": "%s"
+				}
+			]
+		}
+	}
+	`, vmReady, status)
+
+	return defaultHttpTestServer(map[string]func(w http.ResponseWriter, req *http.Request){
+		"/api/v1/instances/terminate": func(w http.ResponseWriter, _ *http.Request) {
+			terminated = true
+			w.WriteHeader(http.StatusOK)
+		},
+		"/api/v1/instances/list": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "json")
+			w.WriteHeader(http.StatusOK)
+			if terminated {
+				_, _ = w.Write([]byte(`{"data": {"instances": []}}`))
+				return
+			}
+			_, _ = w.Write([]byte(instanceResponse))
+		},
+		"/api/v1/instances/rent": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`
+				{
+					"data": {
+					 	"instance_ids": [
+							"1"
+						]
+					}
+				}
+			`))
+		},
+		"/api/v1/ssh-keys/add":   sshKeyAddHandler(),
+		"/api/v1/ssh-keys/list":  sshKeyListHandlerWithKey(keyName, publicKey),
+		"/api/v1/ssh-keys/11111": sshKeyDeleteHandler(),
 	})
 }
 


### PR DESCRIPTION
## Summary

- Reduce VM create timeout from 28 min to 5 min
- Add 5 min timeout to VM delete (previously had none — polled forever)
- Fail fast on terminal instance status (`Inactive`, `Deactivating`) during create
- Fail fast on unhealthy node status (`Offline`, `NotResponding`, `Hibernated`) during create
- Add tests for `Inactive` and `Deactivating` failure paths

## Context

When a VM is not available (e.g. no GPU capacity), the provider would hang for up to 28 minutes on create, or indefinitely on delete. This caused long feedback loops and stuck Terraform runs in production (Claudie inference deployments).

## Test plan

- [x] `Test_VirtualMachineResource_FailsOnInactiveStatus` — verifies create fails when API returns Inactive
- [x] `Test_VirtualMachineResource_FailsOnDeactivatingStatus` — verifies create fails fast on Deactivating
- [x] Full test suite passes (`go test -v ./internal/provider/`)
- [x] Manually tested against real CloudRift API with unavailable instance type (`rtx49-15-80-400-ec.1` in `eu-west-uk-lo-1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced VM provisioning polling timeout from 28 minutes to 5 minutes and added "fail-fast" behavior when instances enter terminal or unresponsive states.
  * Added a 5-minute timeout for VM deletion operations with a clear "destruction timeout" failure outcome.

* **Tests**
  * Added acceptance tests validating failure scenarios for VM provisioning and delete-timeout/state-transition behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->