### PR TITLE
fix: prevent apply/destroy deadlock when VM reaches Deactivating

### DIFF
--- a/internal/provider/virtual_machine_resource.go
+++ b/internal/provider/virtual_machine_resource.go
@@ -281,16 +281,35 @@ func (r *virtualMachineResource) Create(ctx context.Context, req resource.Create
 	}
 
 	id := ids.Data.InstanceIds[0]
-	plan.ID = types.StringValue(id) // always assign at least the ID to the state file.
+	plan.ID = types.StringValue(id)
 
 	var last *cloudriftapi.InstanceAndUsageInfo
 
 	// savePartialState persists whatever we know about the instance so far.
+	// Use only on paths where the VM may still become Active on a retry
+	// (transient polling errors, user cancel). Do NOT use on hard-failure
+	// paths where the VM will never come up — those must leave state empty
+	// so Terraform treats the resource as never created and retries a fresh
+	// Create instead of planning a Destroy on a zombie ID.
 	savePartialState := func() {
 		if last != nil {
 			resp.Diagnostics.Append(populateModelFromInstanceResponse(&plan, last)...)
 		}
 		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	}
+
+	// abandonRentedInstance releases the backend-side VM on hard-failure paths
+	// and intentionally leaves Terraform state empty (no resp.State.Set). The
+	// terminate call is best-effort — if it fails the backend's own state
+	// machine will still deactivate the instance; we log via a warning
+	// diagnostic so operators can see it in terraform output.
+	abandonRentedInstance := func(reason string) {
+		if err := r.client.TerminateInstance(id); err != nil && !errors.Is(err, cloudriftapi.ErrNotFound) {
+			resp.Diagnostics.AddWarning(
+				"Best-effort termination of failed VM did not succeed",
+				fmt.Sprintf("After %s, attempted to terminate instance %s to avoid leaking a rented VM, but the call failed: %s. The backend may still deactivate the instance on its own.", reason, id, err.Error()),
+			)
+		}
 	}
 
 	// The provisioning timeout covers the case where the VM never reaches a
@@ -302,7 +321,8 @@ func (r *virtualMachineResource) Create(ctx context.Context, req resource.Create
 	for {
 		select {
 		case <-provisioningTimeout:
-			savePartialState()
+			// Hard failure: give up on this VM, release it, and leave no state.
+			abandonRentedInstance("provisioning timeout")
 			resp.Diagnostics.AddError(
 				"Provisioning timeout reached",
 				"Provisioning timeout reached before finished waiting on instance creation",
@@ -310,6 +330,8 @@ func (r *virtualMachineResource) Create(ctx context.Context, req resource.Create
 			return
 
 		case <-ctx.Done():
+			// User cancel: keep partial state so the user can decide whether
+			// to `terraform apply` to resume or `terraform state rm` to drop.
 			savePartialState()
 			if err := ctx.Err(); err != nil {
 				resp.Diagnostics.AddError(
@@ -323,6 +345,8 @@ func (r *virtualMachineResource) Create(ctx context.Context, req resource.Create
 			current, err := r.client.GetInstance(id)
 			if err != nil {
 				if !errors.Is(err, cloudriftapi.ErrNotFound) {
+					// Transient polling error: the VM may still be healthy,
+					// persist state so a retry can reconcile.
 					savePartialState()
 				}
 				resp.Diagnostics.AddError(
@@ -339,7 +363,10 @@ func (r *virtualMachineResource) Create(ctx context.Context, req resource.Create
 			// Note: Inactive is not checked here because GetInstance already
 			// converts it to ErrNotFound, which is handled above.
 			if last.Status == cloudriftapi.Deactivating {
-				savePartialState()
+				// Hard failure: release the VM and leave no Terraform state,
+				// so the next apply produces a fresh create rather than
+				// attempting to destroy a stuck-Deactivating zombie.
+				abandonRentedInstance(fmt.Sprintf("instance reached terminal status %q", last.Status))
 				resp.Diagnostics.AddError(
 					"Virtual Machine provisioning failed",
 					fmt.Sprintf("Instance %s reached terminal status %q instead of becoming active", id, last.Status),
@@ -350,7 +377,8 @@ func (r *virtualMachineResource) Create(ctx context.Context, req resource.Create
 			// Fail fast if the underlying node is unhealthy.
 			switch last.NodeStatus {
 			case cloudriftapi.Offline, cloudriftapi.NotResponding, cloudriftapi.Hibernated:
-				savePartialState()
+				// Hard failure: same reasoning as the terminal-status path.
+				abandonRentedInstance(fmt.Sprintf("node is %q", last.NodeStatus))
 				resp.Diagnostics.AddError(
 					"Virtual Machine provisioning failed",
 					fmt.Sprintf("Instance %s node is %q — VM cannot be provisioned on an unhealthy node", id, last.NodeStatus),
@@ -427,14 +455,16 @@ func (r *virtualMachineResource) Delete(ctx context.Context, req resource.Delete
 		return
 	}
 
-	if err := r.client.TerminateInstance(state.ID.ValueString()); err != nil {
+	id := state.ID.ValueString()
+
+	if err := r.client.TerminateInstance(id); err != nil {
 		if errors.Is(err, cloudriftapi.ErrNotFound) {
 			// resource already deleted from outside the terraform state.
 			return
 		}
 		resp.Diagnostics.AddError(
 			"Error Delete Virtual Machine",
-			"Could not delete Virtual Machine with ID "+state.ID.ValueString()+": "+err.Error(),
+			"Could not delete Virtual Machine with ID "+id+": "+err.Error(),
 		)
 		return
 	}
@@ -446,7 +476,7 @@ func (r *virtualMachineResource) Delete(ctx context.Context, req resource.Delete
 		case <-destructionTimeout:
 			resp.Diagnostics.AddError(
 				"Destruction timeout reached",
-				"Destruction timeout reached before finished waiting on instance deletion for ID: "+state.ID.ValueString(),
+				"Destruction timeout reached before finished waiting on instance deletion for ID: "+id,
 			)
 			return
 
@@ -463,17 +493,24 @@ func (r *virtualMachineResource) Delete(ctx context.Context, req resource.Delete
 			}
 			return
 		case <-time.After(InstancePollingInterval):
-			// Wait until the Instance is gone.
-			// GetInstance returns ErrNotFound once the instance reaches Inactive.
-			if _, err := r.client.GetInstance(state.ID.ValueString()); err != nil {
+			// The instance is considered gone from Terraform's perspective as
+			// soon as the backend acknowledges deactivation — either by
+			// returning ErrNotFound (Inactive) or by reporting Deactivating
+			// status. We don't need to wait for the backend's own
+			// Deactivating→Inactive transition, which can stall indefinitely
+			// on capacity-failure cases.
+			current, err := r.client.GetInstance(id)
+			if err != nil {
 				if errors.Is(err, cloudriftapi.ErrNotFound) {
-					// Successfully destroyed.
 					return
 				}
 				resp.Diagnostics.AddError(
 					"Client Error",
 					"Polling Instance while marked for deletion: "+err.Error(),
 				)
+				return
+			}
+			if current.Status == cloudriftapi.Deactivating {
 				return
 			}
 		}

--- a/internal/provider/virtual_machine_resource.go
+++ b/internal/provider/virtual_machine_resource.go
@@ -344,7 +344,12 @@ func (r *virtualMachineResource) Create(ctx context.Context, req resource.Create
 		case <-time.After(InstancePollingInterval):
 			current, err := r.client.GetInstance(id)
 			if err != nil {
-				if !errors.Is(err, cloudriftapi.ErrNotFound) {
+				if errors.Is(err, cloudriftapi.ErrNotFound) {
+					// Hard failure: the instance is gone (Inactive or not
+					// listed). Best-effort terminate to stay consistent with
+					// the other hard-failure branches, and leave no state.
+					abandonRentedInstance("instance not found during provisioning (Inactive or removed)")
+				} else {
 					// Transient polling error: the VM may still be healthy,
 					// persist state so a retry can reconcile.
 					savePartialState()

--- a/internal/provider/virtual_machine_resource_test.go
+++ b/internal/provider/virtual_machine_resource_test.go
@@ -101,7 +101,7 @@ func Test_VirtualMachineResource_FailsOnInactiveStatus(t *testing.T) {
 	// Simulate a VM that goes Inactive after rent (e.g. no capacity).
 	// Note: GetInstance converts Inactive to ErrNotFound at the client level,
 	// so the provider sees a "resource not found" error rather than the status.
-	server, _ := newVMTestServerWithStatus(keyName, publicKey, "Inactive", false)
+	server, terminateCalls := newVMTestServerWithStatus(keyName, publicKey, "Inactive", false)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -124,6 +124,14 @@ func Test_VirtualMachineResource_FailsOnInactiveStatus(t *testing.T) {
 			},
 		},
 	})
+
+	// Same contract as the Deactivating path: on any hard failure during
+	// provisioning, Create must best-effort terminate the rented instance to
+	// keep behavior symmetric and avoid relying on the backend to always
+	// deactivate on its own.
+	if got := atomic.LoadInt32(terminateCalls); got < 1 {
+		t.Fatalf("expected Create to call /instances/terminate at least once on Inactive failure, got %d calls", got)
+	}
 }
 
 func Test_VirtualMachineResource_FailsOnDeactivatingStatus(t *testing.T) {

--- a/internal/provider/virtual_machine_resource_test.go
+++ b/internal/provider/virtual_machine_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"sync/atomic"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -100,7 +101,7 @@ func Test_VirtualMachineResource_FailsOnInactiveStatus(t *testing.T) {
 	// Simulate a VM that goes Inactive after rent (e.g. no capacity).
 	// Note: GetInstance converts Inactive to ErrNotFound at the client level,
 	// so the provider sees a "resource not found" error rather than the status.
-	server := newVMTestServerWithStatus(keyName, publicKey, "Inactive", false)
+	server, _ := newVMTestServerWithStatus(keyName, publicKey, "Inactive", false)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -132,7 +133,7 @@ func Test_VirtualMachineResource_FailsOnDeactivatingStatus(t *testing.T) {
 	publicKey := "ssh-rsa AAAA anotheruser"
 
 	// Simulate a VM that goes Deactivating after rent.
-	server := newVMTestServerWithStatus(keyName, publicKey, "Deactivating", false)
+	server, terminateCalls := newVMTestServerWithStatus(keyName, publicKey, "Deactivating", false)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -155,12 +156,24 @@ func Test_VirtualMachineResource_FailsOnDeactivatingStatus(t *testing.T) {
 			},
 		},
 	})
+
+	// When Create fails on a terminal status, the provider must best-effort
+	// terminate the rented instance so it doesn't leak on the backend while
+	// Terraform's state is left empty. At least one terminate call is
+	// required; additional calls during test-framework cleanup are allowed
+	// but not required (state should be empty so cleanup is a no-op).
+	if got := atomic.LoadInt32(terminateCalls); got < 1 {
+		t.Fatalf("expected Create to call /instances/terminate at least once to release the failed VM, got %d calls", got)
+	}
 }
 
 // newVMTestServerWithStatus creates a test server where the instance reports
 // the given status and VM readiness. After terminate is called, the instance
 // list returns empty so the test framework's destroy cleanup completes.
-func newVMTestServerWithStatus(keyName, publicKey, status string, vmReady bool) *httptest.Server {
+// The returned int32 pointer counts how many /instances/terminate calls the
+// server has observed — used to verify best-effort cleanup on failed creates.
+func newVMTestServerWithStatus(keyName, publicKey, status string, vmReady bool) (*httptest.Server, *int32) {
+	var terminateCalls int32
 	terminated := false
 
 	instanceResponse := fmt.Sprintf(`
@@ -192,8 +205,9 @@ func newVMTestServerWithStatus(keyName, publicKey, status string, vmReady bool) 
 	}
 	`, vmReady, status)
 
-	return defaultHttpTestServer(map[string]func(w http.ResponseWriter, req *http.Request){
+	server := defaultHttpTestServer(map[string]func(w http.ResponseWriter, req *http.Request){
 		"/api/v1/instances/terminate": func(w http.ResponseWriter, _ *http.Request) {
+			atomic.AddInt32(&terminateCalls, 1)
 			terminated = true
 			w.WriteHeader(http.StatusOK)
 		},
@@ -223,6 +237,8 @@ func newVMTestServerWithStatus(keyName, publicKey, status string, vmReady bool) 
 		"/api/v1/ssh-keys/list":  sshKeyListHandlerWithKey(keyName, publicKey),
 		"/api/v1/ssh-keys/11111": sshKeyDeleteHandler(),
 	})
+
+	return server, &terminateCalls
 }
 
 // newVMTestServer creates a test server with instance, SSH key, and rent
@@ -278,6 +294,119 @@ func newVMTestServer(keyName, publicKey string, onRent func(req *http.Request)) 
 				{
 					"data": {
 					 	"instance_ids": [
+							"1"
+						]
+					}
+				}
+			`))
+		},
+		"/api/v1/ssh-keys/add":   sshKeyAddHandler(),
+		"/api/v1/ssh-keys/list":  sshKeyListHandlerWithKey(keyName, publicKey),
+		"/api/v1/ssh-keys/11111": sshKeyDeleteHandler(),
+	})
+}
+
+// Test_VirtualMachineResource_DeleteOnStuckDeactivating verifies that Delete
+// treats an instance reporting Deactivating status as destroyed, rather than
+// polling until the 5-minute timeout.
+//
+// Scenario: the VM provisions successfully (Active). The user runs terraform
+// destroy. The backend accepts the terminate request and flips the instance
+// into Deactivating, but — as seen in production when GPU capacity is tight —
+// never completes the Deactivating→Inactive transition within the polling
+// window. Before the fix, Delete would poll for 5 minutes and error with
+// "Destruction timeout reached"; combined with the Create-side state-leak bug,
+// this produced a permanent apply/destroy loop in consumers like Claudie.
+func Test_VirtualMachineResource_DeleteOnStuckDeactivating(t *testing.T) {
+	t.Parallel()
+
+	keyName := "anotheruser-key"
+	publicKey := "ssh-rsa AAAA anotheruser"
+	server := newVMTestServerStuckDeactivating(keyName, publicKey)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Step 1 creates the VM (server reports Active+ready).
+				// The framework's implicit destroy at the end of the test
+				// exercises the Delete path against a backend that will
+				// keep returning Deactivating forever after terminate —
+				// this must still return success in well under 5 minutes.
+				Config: providerConfig(server.URL, "1.0") + fmt.Sprintf(`
+					resource "cloudrift_ssh_key" "primary" {
+					  name       = "%s"
+					  public_key = "%s"
+					}
+
+					resource "cloudrift_virtual_machine" "machine0" {
+					  recipe        = "ubuntu"
+					  datacenter    = "us-east-nc-nr-1"
+					  instance_type = "rtx49-10c-kn.1"
+					  ssh_key_id    = cloudrift_ssh_key.primary.id
+					}
+				`, keyName, publicKey),
+			},
+		},
+	})
+}
+
+// newVMTestServerStuckDeactivating starts as Active+ready (so Create
+// succeeds), and after the first /instances/terminate call flips the instance
+// to Deactivating and leaves it there indefinitely — never returning empty
+// or Inactive. This simulates the CloudRift backend getting stuck mid-teardown
+// when capacity is tight.
+func newVMTestServerStuckDeactivating(keyName, publicKey string) *httptest.Server {
+	status := "Active"
+	instanceResponse := `
+	{
+		"data": {
+			"instances": [
+				{
+					"id": "1",
+					"node_id": "1",
+					"node_mode": "Virtual Machine",
+					"node_status": "Ready",
+					"host_address": "127.0.0.1",
+					"internal_host_address": "10.0.0.1",
+					"resource_info": {
+						"provider_name": "provider",
+						"instance_type": "rtx49-10c-kn.1"
+					},
+					"virtual_machines": [
+						{
+							"vmid": 100,
+							"name": "vm-1",
+							"ready": true
+						}
+					],
+					"status": "%s"
+				}
+			]
+		}
+	}
+	`
+
+	return defaultHttpTestServer(map[string]func(w http.ResponseWriter, req *http.Request){
+		"/api/v1/instances/terminate": func(w http.ResponseWriter, _ *http.Request) {
+			// Simulate backend acknowledging the terminate request but
+			// getting stuck: status flips to Deactivating and never
+			// advances to Inactive.
+			status = "Deactivating"
+			w.WriteHeader(http.StatusOK)
+		},
+		"/api/v1/instances/list": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(fmt.Appendf(nil, instanceResponse, status))
+		},
+		"/api/v1/instances/rent": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`
+				{
+					"data": {
+						"instance_ids": [
 							"1"
 						]
 					}


### PR DESCRIPTION
Fixes #33.

## What was broken

When a VM failed to provision because it went straight to `Deactivating` (usually GPU capacity), two things went wrong:

1. The failed VM was saved into Terraform state.
2. The next `terraform apply` tried to destroy that zombie, but destroy timed out after 5 minutes because the backend stayed in `Deactivating`.

Result: a loop that Claudie (and anyone else) couldn't escape without manual state surgery.

## What changed

- **Create:** on a terminal failure, release the VM on the backend and do not write state. Terraform sees "never created" and will retry cleanly next time.
- **Delete:** treat `Deactivating` as "gone." No need to wait for the backend to reach `Inactive` — destroy returns immediately.

## Tests

- Existing `FailsOnDeactivatingStatus` now also checks that terminate was called during cleanup.
- New `DeleteOnStuckDeactivating` test: backend stays in `Deactivating` forever after terminate — destroy still succeeds in seconds.

## Manually verified

Reproduced the original failure with a real CloudRift apply → got the `Deactivating` error → `tofu destroy` reports "No objects need to be destroyed" (state is clean).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced provisioning failure handling to properly clean up instances on hard failures instead of leaving partial state in Terraform
  * Improved deletion flow to return when deactivation begins rather than waiting indefinitely for complete removal
  * Fixed behavior for instances stuck in deactivating state
<!-- end of auto-generated comment: release notes by coderabbit.ai -->