### PR TITLE
Add with_public_ip input to request shared-IP instances

### DIFF
--- a/docs/resources/virtual_machine.md
+++ b/docs/resources/virtual_machine.md
@@ -25,6 +25,7 @@ Manage virtualMachines
 ### Optional
 
 - `metadata` (Attributes) Option to provide metadata. Currently supported is `startup_commands`. (see [below for nested schema](#nestedatt--metadata))
+- `with_public_ip` (Boolean) Whether to allocate a dedicated public IP from the pool. Defaults to true. Set to false to request a shared public IP with port forwarding (the assigned host ports are exposed via port_mappings).
 
 ### Read-Only
 

--- a/internal/provider/virtual_machine_resource.go
+++ b/internal/provider/virtual_machine_resource.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -65,10 +67,11 @@ type virtualMachineModel struct {
 	PortMappings    types.List `tfsdk:"port_mappings"`
 
 	// Write only attributes.
-	Metadata   *virtualMachineMetadataModel `tfsdk:"metadata"`
-	Recipe     types.String                 `tfsdk:"recipe"`
-	Datacenter types.String                 `tfsdk:"datacenter"`
-	SSHKeyID   types.String                 `tfsdk:"ssh_key_id"`
+	Metadata     *virtualMachineMetadataModel `tfsdk:"metadata"`
+	Recipe       types.String                 `tfsdk:"recipe"`
+	Datacenter   types.String                 `tfsdk:"datacenter"`
+	SSHKeyID     types.String                 `tfsdk:"ssh_key_id"`
+	WithPublicIP types.Bool                   `tfsdk:"with_public_ip"`
 }
 
 type virtualMachineResource struct {
@@ -224,6 +227,17 @@ func (r *virtualMachineResource) Schema(_ context.Context, req resource.SchemaRe
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"with_public_ip": schema.BoolAttribute{
+				MarkdownDescription: "Whether to allocate a dedicated public IP from the pool. " +
+					"Defaults to true. Set to false to request a shared public IP with port " +
+					"forwarding (the assigned host ports are exposed via port_mappings).",
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(true),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
+			},
 		},
 	}
 }
@@ -272,6 +286,7 @@ func (r *virtualMachineResource) Create(ctx context.Context, req resource.Create
 		plan.InstanceType.ValueString(),
 		startupCommands,
 		[]string{matched.PublicKey},
+		plan.WithPublicIP.ValueBool(),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/pkg/cloudriftapi/custom_client.go
+++ b/pkg/cloudriftapi/custom_client.go
@@ -334,7 +334,7 @@ func (c *HttpClient) TerminateInstance(id string) error {
 	return err
 }
 
-func (c *HttpClient) RentPublicInstanceVM(recipe, datacenter, instance, commands string, pubKeys []string) (*RentInstanceResponseProto, error) {
+func (c *HttpClient) RentPublicInstanceVM(recipe, datacenter, instance, commands string, pubKeys []string, withPublicIp bool) (*RentInstanceResponseProto, error) {
 	if recipe == "" {
 		return nil, errors.New("no image specified")
 	}
@@ -401,7 +401,7 @@ func (c *HttpClient) RentPublicInstanceVM(recipe, datacenter, instance, commands
 
 	var reqData RentInstanceRequestProto
 	reqData.Data.Selector = instanceSelector
-	reqData.Data.WithPublicIp = true
+	reqData.Data.WithPublicIp = withPublicIp
 	reqData.Data.Config = instanceConfiguration
 	if c.TeamID != "" {
 		reqData.Data.TeamId = &c.TeamID


### PR DESCRIPTION
Adds an optional with_public_ip attribute (default true) to cloudrift_virtual_machine and threads it into the rent request.

When set to false the VM is requested with a shared public IP and port forwarding instead of a dedicated public IP. The default keeps the current behavior, so existing configs are unaffected.