### PR TITLE
feat: add optional name attribute to virtual_machine resource

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,7 @@ jobs:
     env:
       CLOUDRIFT_TOKEN: ${{ secrets.CLOUDRIFT_TOKEN }}
       CLOUDRIFT_TEAM_ID: ${{ secrets.CLOUDRIFT_TEAM_ID }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/docs/resources/virtual_machine.md
+++ b/docs/resources/virtual_machine.md
@@ -25,6 +25,7 @@ Manage virtualMachines
 ### Optional
 
 - `metadata` (Attributes) Option to provide metadata. Currently supported is `startup_commands`. (see [below for nested schema](#nestedatt--metadata))
+- `name` (String) Optional name for the Virtual Machine, shown in the CloudRift dashboard. Changing it forces replacement.
 
 ### Read-Only
 

--- a/internal/provider/acceptance_test.go
+++ b/internal/provider/acceptance_test.go
@@ -171,13 +171,12 @@ func TestAcc_VirtualMachineResource(t *testing.T) {
 	keyName := fmt.Sprintf("ci-test-vm-%d", time.Now().UnixNano())
 	recipe := "Ubuntu 24.04 Server"
 
-	// Name the VM after the PR (or "local" when run outside CI) plus a random
-	// id, so dashboard entries are traceable instead of randomly named.
-	prNumber := os.Getenv("PR_NUMBER")
-	if prNumber == "" {
-		prNumber = "local"
+	// Name the VM after the PR (or "master" for non-PR runs) plus a random id,
+	// so dashboard entries are traceable instead of randomly named.
+	vmName := fmt.Sprintf("provider-test-master-%d", time.Now().UnixNano())
+	if pr := os.Getenv("PR_NUMBER"); pr != "" {
+		vmName = fmt.Sprintf("provider-test-pr-%s-%d", pr, time.Now().UnixNano())
 	}
-	vmName := fmt.Sprintf("acc-test-pr-%s-%d", prNumber, time.Now().UnixNano())
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/acceptance_test.go
+++ b/internal/provider/acceptance_test.go
@@ -171,6 +171,14 @@ func TestAcc_VirtualMachineResource(t *testing.T) {
 	keyName := fmt.Sprintf("ci-test-vm-%d", time.Now().UnixNano())
 	recipe := "Ubuntu 24.04 Server"
 
+	// Name the VM after the PR (or "local" when run outside CI) plus a random
+	// id, so dashboard entries are traceable instead of randomly named.
+	prNumber := os.Getenv("PR_NUMBER")
+	if prNumber == "" {
+		prNumber = "local"
+	}
+	vmName := fmt.Sprintf("acc-test-pr-%s-%d", prNumber, time.Now().UnixNano())
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -184,13 +192,15 @@ func TestAcc_VirtualMachineResource(t *testing.T) {
 					}
 
 					resource "cloudrift_virtual_machine" "test" {
+						name          = %q
 						recipe        = %q
 						datacenter    = %q
 						instance_type = %q
 						ssh_key_id    = cloudrift_ssh_key.test.id
 					}
-				`, keyName, sshPublicKey, recipe, instance.datacenter, instance.variantName),
+				`, keyName, sshPublicKey, vmName, recipe, instance.datacenter, instance.variantName),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("cloudrift_virtual_machine.test", "name", vmName),
 					resource.TestCheckResourceAttrSet("cloudrift_virtual_machine.test", "id"),
 					resource.TestCheckResourceAttrSet("cloudrift_virtual_machine.test", "public_ip"),
 					resource.TestCheckResourceAttr("cloudrift_virtual_machine.test", "status", "Active"),

--- a/internal/provider/virtual_machine_resource.go
+++ b/internal/provider/virtual_machine_resource.go
@@ -65,6 +65,7 @@ type virtualMachineModel struct {
 	PortMappings    types.List `tfsdk:"port_mappings"`
 
 	// Write only attributes.
+	Name       types.String                 `tfsdk:"name"`
 	Metadata   *virtualMachineMetadataModel `tfsdk:"metadata"`
 	Recipe     types.String                 `tfsdk:"recipe"`
 	Datacenter types.String                 `tfsdk:"datacenter"`
@@ -203,6 +204,13 @@ func (r *virtualMachineResource) Schema(_ context.Context, req resource.SchemaRe
 					},
 				},
 			},
+			"name": schema.StringAttribute{
+				MarkdownDescription: "Optional name for the Virtual Machine, shown in the CloudRift dashboard. Changing it forces replacement.",
+				Optional:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
 			"recipe": schema.StringAttribute{
 				MarkdownDescription: "The Base Image used for the Virtual Machine",
 				Required:            true,
@@ -271,6 +279,7 @@ func (r *virtualMachineResource) Create(ctx context.Context, req resource.Create
 		plan.Datacenter.ValueString(),
 		plan.InstanceType.ValueString(),
 		startupCommands,
+		plan.Name.ValueString(),
 		[]string{matched.PublicKey},
 	)
 	if err != nil {

--- a/internal/provider/virtual_machine_resource_test.go
+++ b/internal/provider/virtual_machine_resource_test.go
@@ -66,6 +66,56 @@ func Test_VirtualMachineResource_TeamId(t *testing.T) {
 	})
 }
 
+func Test_VirtualMachineResource_Name(t *testing.T) {
+	t.Parallel()
+
+	keyName := "anotheruser-key"
+	publicKey := "ssh-rsa AAAA anotheruser"
+	vmName := "mycluster-a3f2-pool1-01"
+	var capturedName string
+
+	server := newVMTestServer(keyName, publicKey, func(req *http.Request) {
+		body, _ := io.ReadAll(req.Body)
+		var parsed struct {
+			Data struct {
+				Name *string `json:"name"`
+			} `json:"data"`
+		}
+		_ = json.Unmarshal(body, &parsed)
+		if parsed.Data.Name != nil {
+			capturedName = *parsed.Data.Name
+		}
+	})
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig(server.URL, "1.0") + fmt.Sprintf(`
+					resource "cloudrift_ssh_key" "primary" {
+					  name       = "%s"
+					  public_key = "%s"
+					}
+
+					resource "cloudrift_virtual_machine" "machine0" {
+					  name          = "%s"
+					  recipe        = "ubuntu"
+					  datacenter    = "us-east-nc-nr-1"
+					  instance_type = "rtx49-10c-kn.1"
+					  ssh_key_id    = cloudrift_ssh_key.primary.id
+					}
+				`, keyName, publicKey, vmName),
+				Check: resource.TestCheckFunc(func(s *terraform.State) error {
+					if capturedName != vmName {
+						return fmt.Errorf("expected name %q in rent request, got %q", vmName, capturedName)
+					}
+					return nil
+				}),
+			},
+		},
+	})
+}
+
 func Test_VirtualMachineResrouce(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cloudriftapi/custom_client.go
+++ b/pkg/cloudriftapi/custom_client.go
@@ -334,7 +334,7 @@ func (c *HttpClient) TerminateInstance(id string) error {
 	return err
 }
 
-func (c *HttpClient) RentPublicInstanceVM(recipe, datacenter, instance, commands string, pubKeys []string) (*RentInstanceResponseProto, error) {
+func (c *HttpClient) RentPublicInstanceVM(recipe, datacenter, instance, commands, name string, pubKeys []string) (*RentInstanceResponseProto, error) {
 	if recipe == "" {
 		return nil, errors.New("no image specified")
 	}
@@ -403,6 +403,9 @@ func (c *HttpClient) RentPublicInstanceVM(recipe, datacenter, instance, commands
 	reqData.Data.Selector = instanceSelector
 	reqData.Data.WithPublicIp = true
 	reqData.Data.Config = instanceConfiguration
+	if name != "" {
+		reqData.Data.Name = &name
+	}
 	if c.TeamID != "" {
 		reqData.Data.TeamId = &c.TeamID
 	}


### PR DESCRIPTION
## What

Adds an optional `name` attribute to the `cloudrift_virtual_machine` resource.

## Why

The CloudRift API already accepts an optional instance name, but the provider never exposed it. As a result VMs got random platform-assigned names in the dashboard, with no way to match them to the names used in Terraform.

## How

- `name` is optional and write-only, sent at create time.
- Changing it forces replacement, since a rented VM can't be renamed in place.
- No backend or generated-client changes needed.
- Acceptance tests now set a traceable VM name (`provider-test-pr-<PR>-<id>`, or `provider-test-master-<id>` for non-PR runs) instead of leaving it random.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Virtual machines now support an optional custom name attribute. Assigned names are displayed in the CloudRift dashboard, and updating the name will trigger resource recreation.

* **Tests**
  * Enhanced acceptance tests to validate VM name functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->