### PR TITLE
Stop stale/transient resource states from wedging a reconcile

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -59,5 +59,6 @@ also set `team_id` or `CLOUDRIFT_TEAM_ID`.
 
 - `base_url` (String) Base URL for the CloudRift platform API. If not specified the provider has a built in default Base URL that will be used.May also be provided via CLOUDRIFT_BASE_URL environment variable.
 - `proto_version` (String) Protocol Version to be used for the CloudRift platform API.If not specified the provider has a built in default version that will be used. May also be provided via CLOUDRIFT_PROTO_VERSION environment variable.
+- `request_timeout` (String) Per-request HTTP timeout as a Go duration string (e.g. `30s`, `1m`). Raise it if the CloudRift API is slow to respond on large teams. Defaults to 30s. May also be provided via CLOUDRIFT_REQUEST_TIMEOUT environment variable.
 - `team_id` (String) Team ID for team-scoped operations (instance provisioning). May also be provided via CLOUDRIFT_TEAM_ID environment variable.
 - `token` (String, Sensitive) Token for CloudRift platform API. May also be provided via CLOUDRIFT_TOKEN environment variable.

--- a/internal/provider/custom_client_timeout_test.go
+++ b/internal/provider/custom_client_timeout_test.go
@@ -1,0 +1,66 @@
+package provider
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/berops/terraform-provider-cloudrift/pkg/cloudriftapi"
+)
+
+// slowInstanceListServer returns a test server whose /instances/list handler
+// sleeps for `delay` before responding with a single Active instance (id "1").
+// Auth/recipes handlers stay fast so NewCustom construction succeeds.
+func slowInstanceListServer(delay time.Duration) *httptest.Server {
+	return defaultHttpTestServer(map[string]func(w http.ResponseWriter, req *http.Request){
+		"/api/v1/instances/list": func(w http.ResponseWriter, _ *http.Request) {
+			time.Sleep(delay)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{"instances":[{"id":"1","node_id":"1","node_mode":"Virtual Machine","node_status":"Ready","status":"Active"}]}}`))
+		},
+	})
+}
+
+// A generous timeout lets a slow /instances/list complete: GetInstance returns
+// the instance instead of hard-failing (the reported wedge).
+func Test_GetInstance_SlowResponse_SucceedsWithTimeout(t *testing.T) {
+	server := slowInstanceListServer(50 * time.Millisecond)
+	defer server.Close()
+
+	client, err := cloudriftapi.NewCustom(server.URL, "test", "", "", cloudriftapi.WithTimeout(5*time.Second))
+	if err != nil {
+		t.Fatalf("NewCustom: %v", err)
+	}
+
+	vm, err := client.GetInstance("1")
+	if err != nil {
+		t.Fatalf("GetInstance with generous timeout should succeed, got: %v", err)
+	}
+	if vm.Id != "1" {
+		t.Fatalf("expected instance id 1, got %q", vm.Id)
+	}
+}
+
+// A too-short timeout still surfaces an honest error — it must NOT be swallowed
+// or misread as not-found (which would drop the resource from state and leak a
+// recreate).
+func Test_GetInstance_SlowResponse_ErrorsWhenTimeoutTooShort(t *testing.T) {
+	server := slowInstanceListServer(150 * time.Millisecond)
+	defer server.Close()
+
+	client, err := cloudriftapi.NewCustom(server.URL, "test", "", "", cloudriftapi.WithTimeout(50*time.Millisecond))
+	if err != nil {
+		t.Fatalf("NewCustom: %v", err)
+	}
+
+	_, err = client.GetInstance("1")
+	if err == nil {
+		t.Fatal("GetInstance should error when the timeout is shorter than the response")
+	}
+	if errors.Is(err, cloudriftapi.ErrNotFound) {
+		t.Fatal("a timeout must not be reported as ErrNotFound")
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"os"
+	"time"
 
 	"github.com/berops/terraform-provider-cloudrift/pkg/cloudriftapi"
 
@@ -36,6 +37,10 @@ type CloudRiftProviderModel struct {
 
 	// Optional Team ID for team-scoped operations (instance provisioning).
 	TeamID types.String `tfsdk:"team_id"`
+
+	// Optional per-request HTTP timeout (Go duration string, e.g. "30s").
+	// If not set the provider uses cloudriftapi.DefaultRequestTimeout.
+	RequestTimeout types.String `tfsdk:"request_timeout"`
 }
 
 type CloudRiftProvider struct {
@@ -79,6 +84,13 @@ func (p *CloudRiftProvider) Schema(ctx context.Context, req provider.SchemaReque
 				Description:         "Team ID for team-scoped operations (instance provisioning). May also be provided via CLOUDRIFT_TEAM_ID environment variable.",
 				MarkdownDescription: "Team ID for team-scoped operations (instance provisioning). May also be provided via CLOUDRIFT_TEAM_ID environment variable.",
 				Optional:            true,
+			},
+			"request_timeout": schema.StringAttribute{
+				Description: "Per-request HTTP timeout as a Go duration string (e.g. \"30s\", \"1m\"). Raise it if the CloudRift API is slow to respond on large teams. Defaults to 30s. " +
+					"May also be provided via CLOUDRIFT_REQUEST_TIMEOUT environment variable.",
+				MarkdownDescription: "Per-request HTTP timeout as a Go duration string (e.g. `30s`, `1m`). Raise it if the CloudRift API is slow to respond on large teams. Defaults to 30s. " +
+					"May also be provided via CLOUDRIFT_REQUEST_TIMEOUT environment variable.",
+				Optional: true,
 			},
 		},
 	}
@@ -128,6 +140,15 @@ func (p *CloudRiftProvider) Configure(ctx context.Context, req provider.Configur
 		)
 	}
 
+	if config.RequestTimeout.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("request_timeout"),
+			"Unknown CloudRift Request Timeout",
+			"The provider cannot create the CloudRift API client as there is an unknown configuration for the CloudRift request timeout."+
+				"Either target apply the source of the value first, set the value statically in the configuration, or use the CLOUDRIFT_REQUEST_TIMEOUT environment variable.",
+		)
+	}
+
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -136,6 +157,7 @@ func (p *CloudRiftProvider) Configure(ctx context.Context, req provider.Configur
 	baseURL := os.Getenv("CLOUDRIFT_BASE_URL")
 	protoVersion := os.Getenv("CLOUDRIFT_PROTO_VERSION")
 	teamID := os.Getenv("CLOUDRIFT_TEAM_ID")
+	requestTimeout := os.Getenv("CLOUDRIFT_REQUEST_TIMEOUT")
 
 	if !config.Token.IsNull() {
 		token = config.Token.ValueString()
@@ -151,6 +173,10 @@ func (p *CloudRiftProvider) Configure(ctx context.Context, req provider.Configur
 
 	if !config.TeamID.IsNull() {
 		teamID = config.TeamID.ValueString()
+	}
+
+	if !config.RequestTimeout.IsNull() {
+		requestTimeout = config.RequestTimeout.ValueString()
 	}
 
 	if baseURL == "" {
@@ -174,11 +200,30 @@ func (p *CloudRiftProvider) Configure(ctx context.Context, req provider.Configur
 		)
 	}
 
+	timeout := cloudriftapi.DefaultRequestTimeout
+	if requestTimeout != "" {
+		d, err := time.ParseDuration(requestTimeout)
+		if err != nil || d <= 0 {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("request_timeout"),
+				"Invalid CloudRift Request Timeout",
+				"request_timeout must be a positive Go duration string (e.g. \"30s\", \"1m\"), got: "+requestTimeout,
+			)
+			return
+		}
+		timeout = d
+	}
+
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	client, err := cloudriftapi.NewCustom(baseURL, token, protoVersion, teamID, cloudriftapi.WithRetryableHttpClient(4))
+	// retries kept low: each attempt now has a generous timeout, so 3 attempts
+	// max is a bounded worst case rather than many short hangs.
+	client, err := cloudriftapi.NewCustom(baseURL, token, protoVersion, teamID,
+		cloudriftapi.WithRetryableHttpClient(2),
+		cloudriftapi.WithTimeout(timeout),
+	)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to create CloudRift API Client",

--- a/internal/provider/virtual_machine_resource.go
+++ b/internal/provider/virtual_machine_resource.go
@@ -360,18 +360,22 @@ func (r *virtualMachineResource) Create(ctx context.Context, req resource.Create
 			return
 
 		case <-time.After(InstancePollingInterval):
-			current, err := r.client.GetInstance(id)
+			current, err := r.client.GetInstanceIncludingInactive(id)
 			if err != nil {
 				if errors.Is(err, cloudriftapi.ErrNotFound) {
-					// Hard failure: the instance is gone (Inactive or not
-					// listed). Best-effort terminate to stay consistent with
-					// the other hard-failure branches, and leave no state.
-					abandonRentedInstance("instance not found during provisioning (Inactive or removed)")
-				} else {
-					// Transient polling error: the VM may still be healthy,
-					// persist state so a retry can reconcile.
-					savePartialState()
+					// The rent call already returned this id, so a not-found
+					// here means the instance is not listed yet (eventual
+					// consistency right after rent). Keep polling instead of
+					// treating it as terminal; a VM that never appears is
+					// released by the <-deadline case. A listed-but-Inactive
+					// instance is a real terminal state and is handled below.
+					tflog.Debug(ctx, "rented instance not listed yet, continuing to poll", map[string]any{"id": id})
+					continue // next poll tick of the outer for
+
 				}
+				// Transient polling error: the VM may still be healthy,
+				// persist state so a retry can reconcile.
+				savePartialState()
 				resp.Diagnostics.AddError(
 					"Error creating Virtual Machine",
 					"Could not create Virtual Machine, failed to poll status of the rented Virtual Machine ID: "+id+" : "+err.Error(),
@@ -382,10 +386,11 @@ func (r *virtualMachineResource) Create(ctx context.Context, req resource.Create
 			last = current
 
 			// Fail fast if the instance entered a terminal non-success state.
-			// This avoids waiting for the full timeout when the VM cannot be provisioned.
-			// Note: Inactive is not checked here because GetInstance already
-			// converts it to ErrNotFound, which is handled above.
-			if last.Status == cloudriftapi.InstanceStatusDeactivating ||
+			// This avoids waiting for the full timeout when the VM cannot be
+			// provisioned. A freshly rented VM that is Inactive (rather than
+			// Initializing) has failed to come up, so it is terminal here.
+			if last.Status == cloudriftapi.InstanceStatusInactive ||
+				last.Status == cloudriftapi.InstanceStatusDeactivating ||
 				last.Status == cloudriftapi.InstanceStatusFailed {
 				// Hard failure: release the VM and leave no Terraform state,
 				// so the next apply produces a fresh create rather than

--- a/internal/provider/virtual_machine_resource_test.go
+++ b/internal/provider/virtual_machine_resource_test.go
@@ -66,6 +66,86 @@ func Test_VirtualMachineResource_TeamId(t *testing.T) {
 	})
 }
 
+// A freshly rented VM can be missing from the first poll (eventual consistency)
+// or briefly Inactive. Create must keep polling through that not-found rather
+// than hard-failing on it.
+func Test_VirtualMachineResource_ToleratesTransientNotFound(t *testing.T) {
+	t.Parallel()
+
+	keyName := "anotheruser-key"
+	publicKey := "ssh-rsa AAAA anotheruser"
+
+	activeResponse := `
+	{
+		"data": {
+			"instances": [
+				{
+					"id": "1",
+					"node_id": "1",
+					"node_mode": "Virtual Machine",
+					"node_status": "Ready",
+					"host_address": "127.0.0.1",
+					"virtual_machines": [{"vmid": 100, "name": "vm-1", "ready": true}],
+					"status": "Active"
+				}
+			]
+		}
+	}`
+
+	var listCalls, terminated int32
+	server := defaultHttpTestServer(map[string]func(w http.ResponseWriter, req *http.Request){
+		"/api/v1/instances/list": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			// After terminate (destroy step), report gone so Delete converges.
+			// Otherwise: first poll not listed yet, subsequent polls Active.
+			if atomic.LoadInt32(&terminated) == 1 || atomic.AddInt32(&listCalls, 1) <= 1 {
+				_, _ = w.Write([]byte(`{"data":{"instances":[]}}`))
+				return
+			}
+			_, _ = w.Write([]byte(activeResponse))
+		},
+		"/api/v1/instances/terminate": func(w http.ResponseWriter, _ *http.Request) {
+			atomic.StoreInt32(&terminated, 1)
+			w.WriteHeader(http.StatusOK)
+		},
+		"/api/v1/instances/rent": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{"instance_ids":["1"]}}`))
+		},
+		"/api/v1/ssh-keys/add":   sshKeyAddHandler(),
+		"/api/v1/ssh-keys/list":  sshKeyListHandlerWithKey(keyName, publicKey),
+		"/api/v1/ssh-keys/11111": sshKeyDeleteHandler(),
+	})
+	defer server.Close()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig(server.URL, "1.0") + fmt.Sprintf(`
+					resource "cloudrift_ssh_key" "primary" {
+					  name       = "%s"
+					  public_key = "%s"
+					}
+
+					resource "cloudrift_virtual_machine" "machine0" {
+					  recipe        = "ubuntu"
+					  datacenter    = "us-east-nc-nr-1"
+					  instance_type = "rtx49-10c-kn.1"
+					  ssh_key_id    = cloudrift_ssh_key.primary.id
+					}
+				`, keyName, publicKey),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("cloudrift_virtual_machine.machine0", "id", "1"),
+					resource.TestCheckResourceAttr("cloudrift_virtual_machine.machine0", "status", "Active"),
+				),
+			},
+		},
+	})
+}
+
 func Test_VirtualMachineResource_Name(t *testing.T) {
 	t.Parallel()
 
@@ -147,8 +227,9 @@ func Test_VirtualMachineResrouce(t *testing.T) {
 
 // Test_VirtualMachineResource_FailsOnTerminalStatus covers every instance
 // status that must abort Create and best-effort terminate the rented VM so it
-// doesn't leak. Inactive is special: GetInstance converts it to ErrNotFound at
-// the client level, so the provider reports a poll error rather than the status.
+// doesn't leak. A freshly rented VM that is listed as Inactive has failed to
+// come up, so Create treats it as terminal (a not-yet-listed id, by contrast,
+// keeps polling — see Test_VirtualMachineResource_ToleratesTransientNotFound).
 func Test_VirtualMachineResource_FailsOnTerminalStatus(t *testing.T) {
 	t.Parallel()
 
@@ -159,7 +240,7 @@ func Test_VirtualMachineResource_FailsOnTerminalStatus(t *testing.T) {
 		status  string
 		wantErr string
 	}{
-		{"Inactive", `failed to poll status`},
+		{"Inactive", `reached terminal status "Inactive"`},
 		{"Deactivating", `reached terminal status "Deactivating"`},
 		{"Failed", `reached terminal status "Failed"`}, // server 0.59.0+
 	} {

--- a/pkg/cloudriftapi/custom_client.go
+++ b/pkg/cloudriftapi/custom_client.go
@@ -36,9 +36,25 @@ const (
 
 type HttpClientOption func(*HttpClient)
 
+// DefaultRequestTimeout caps how long a single request waits for response
+// headers. It must tolerate a heavy team-wide /instances/list (the ByTeamId
+// path returns every team instance); the old 10s tripped on large teams and
+// hard-failed Read, wedging the whole apply. Override with WithTimeout.
+const DefaultRequestTimeout = 30 * time.Second
+
 func WithRetryableHttpClient(retries int) HttpClientOption {
 	return func(hc *HttpClient) {
 		hc.retries = retries
+	}
+}
+
+// WithTimeout overrides the HTTP client timeout. A non-positive duration is
+// ignored, leaving DefaultRequestTimeout in place.
+func WithTimeout(d time.Duration) HttpClientOption {
+	return func(hc *HttpClient) {
+		if d > 0 {
+			hc.HTTPClient.Timeout = d
+		}
 	}
 }
 
@@ -63,7 +79,7 @@ func NewCustom(endpoint, token, protoVersion, teamID string, opts ...HttpClientO
 		auth:    AuthData{Token: token},
 		retries: 0,
 		HTTPClient: &http.Client{
-			Timeout: 10 * time.Second,
+			Timeout: DefaultRequestTimeout,
 		},
 		ProtoVersion: protoVersion,
 		TeamID:       teamID,
@@ -511,6 +527,25 @@ func (c *HttpClient) ListInstances() (*ListInstancesResponseProto, error) {
 		return nil, err
 	}
 	return c.listInstances(selector)
+}
+
+// GetInstanceIncludingInactive is like GetInstance but returns the instance
+// even when its status is Inactive, returning ErrNotFound only when the id is
+// absent from the list. Create uses it to tell a terminal Inactive apart from
+// an id that is simply not listed yet (eventual consistency right after rent).
+func (c *HttpClient) GetInstanceIncludingInactive(id string) (*InstanceAndUsageInfo, error) {
+	instances, err := c.listInstancesForGet(id)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, i := range instances.Data.Instances {
+		if i.Id == id {
+			return &i, nil
+		}
+	}
+
+	return nil, ErrNotFound
 }
 
 func (c *HttpClient) GetInstance(id string) (*InstanceAndUsageInfo, error) {


### PR DESCRIPTION
A single VM could fail an entire `tofu apply`, seen on Claudie clusters after a node went out of sync (e.g. removed from the CloudRift UI while still in Terraform state).

## 1. Configurable request timeout (raise default 10s -> 30s)
The HTTP client timeout was hardcoded at 10s. In team mode `Read` lists the whole team via `ByTeamId`, which grows with lingering `Inactive` VMs and can take longer than 10s. When it did, `Read` hard-errored on the timeout instead of ever inspecting the VM status, failing the whole apply. The graceful "gone -> remove from state -> recreate" path never got to run.

- Default timeout 10s -> 30s.
- New `request_timeout` setting (`CLOUDRIFT_REQUEST_TIMEOUT` env or HCL, Go duration string).
- Retries 4 -> 2 now that each attempt has a real timeout.

A timeout stays an honest error, never treated as not-found, so a slow API cannot silently drop a resource from state.

## 2. VM create: tolerate a not-yet-listed instance, fail fast on a terminal one
The rent call returns the instance id, but in team mode the listing is eventually consistent, so the first status poll can come back not-found. Create treated that as terminal and failed the apply (and abandoned the VM).

- Keep polling while the id is simply not listed yet.
- `GetInstanceIncludingInactive` lets Create tell a not-yet-listed id apart from a listed-but-`Inactive` one, so `Inactive`/`Deactivating`/`Failed` still fail fast (no waiting out the provisioning timeout).

## Testing
- Unit tests for both paths (slow list, transient not-found, terminal statuses).
- `go test` (incl. `TF_ACC=1`), `golangci-lint`, `make generate` all clean.
- Verified against the live API: a UI-terminated VM reads back, drops from state, and plans a recreate; a fresh rent that is not listed for a moment still completes.

## Not included
- The SSH key adopt-on-conflict was reverted for now (taking ownership of a pre-existing key on Create is not idiomatic; import is). May revisit.
- CloudRift returns 500 (not 409) for the SSH key uniqueness violation, and terminate leaves VMs `Inactive` rather than removing them. Worth separate API bug reports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable per-request HTTP timeouts, including a 30-second default.
  - Added support for configuring the timeout through provider settings or the `CLOUDRIFT_REQUEST_TIMEOUT` environment variable.
  - Improved virtual machine provisioning to tolerate brief, temporary missing-instance responses.

- **Bug Fixes**
  - Inactive instances are now recognized as terminal provisioning failures.
  - Invalid timeout values produce clear configuration errors.
  - Documentation now includes the new timeout setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->