### PR TITLE
Add image_url support to cloudrift_virtual_machine

### DIFF
--- a/docs/resources/virtual_machine.md
+++ b/docs/resources/virtual_machine.md
@@ -19,13 +19,14 @@ Manage virtualMachines
 
 - `datacenter` (String) The datacenter identifier
 - `instance_type` (String) The instance type identifier
-- `recipe` (String) The Base Image used for the Virtual Machine
 - `ssh_key_id` (String) The SSH Key ID to be able to connect to the Virtual Machine.
 
 ### Optional
 
+- `image_url` (String) Direct URL of a custom VM image to use, as an alternative to `recipe`. Exactly one of `recipe` or `image_url` must be set.
 - `metadata` (Attributes) Option to provide metadata. Currently supported is `startup_commands`. (see [below for nested schema](#nestedatt--metadata))
 - `name` (String) Optional name for the Virtual Machine, shown in the CloudRift dashboard. Changing it forces replacement.
+- `recipe` (String) The Base Image used for the Virtual Machine. Exactly one of `recipe` or `image_url` must be set.
 
 ### Read-Only
 

--- a/internal/provider/acceptance_test.go
+++ b/internal/provider/acceptance_test.go
@@ -208,3 +208,61 @@ func TestAcc_VirtualMachineResource(t *testing.T) {
 		},
 	})
 }
+
+// pinnedUbuntuCloudImageURL is a dated (non-"current") Ubuntu 24.04 cloud
+// image build, used instead of the "recipe" catalog to test the image_url
+// attribute end-to-end against the real API.
+const pinnedUbuntuCloudImageURL = "https://cloud-images.ubuntu.com/releases/noble/release-20260801/ubuntu-24.04-server-cloudimg-amd64.img"
+
+func TestAcc_VirtualMachineResource_ImageUrl(t *testing.T) {
+	testAccPreCheck(t)
+
+	if os.Getenv("CLOUDRIFT_TEAM_ID") == "" {
+		t.Skip("CLOUDRIFT_TEAM_ID must be set for VM tests")
+	}
+
+	sshPublicKey := os.Getenv("CLOUDRIFT_TEST_SSH_PUBLIC_KEY")
+	if sshPublicKey == "" {
+		t.Skip("CLOUDRIFT_TEST_SSH_PUBLIC_KEY must be set")
+	}
+
+	instance := findCheapestAvailableInstance(t)
+
+	keyName := fmt.Sprintf("ci-test-vm-image-url-%d", time.Now().UnixNano())
+
+	vmName := fmt.Sprintf("provider-test-image-url-master-%d", time.Now().UnixNano())
+	if pr := os.Getenv("PR_NUMBER"); pr != "" {
+		vmName = fmt.Sprintf("provider-test-image-url-pr-%s-%d", pr, time.Now().UnixNano())
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					provider "cloudrift" {}
+
+					resource "cloudrift_ssh_key" "test" {
+						name       = %q
+						public_key = %q
+					}
+
+					resource "cloudrift_virtual_machine" "test" {
+						name          = %q
+						image_url     = %q
+						datacenter    = %q
+						instance_type = %q
+						ssh_key_id    = cloudrift_ssh_key.test.id
+					}
+				`, keyName, sshPublicKey, vmName, pinnedUbuntuCloudImageURL, instance.datacenter, instance.variantName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("cloudrift_virtual_machine.test", "name", vmName),
+					resource.TestCheckResourceAttr("cloudrift_virtual_machine.test", "image_url", pinnedUbuntuCloudImageURL),
+					resource.TestCheckResourceAttrSet("cloudrift_virtual_machine.test", "id"),
+					resource.TestCheckResourceAttrSet("cloudrift_virtual_machine.test", "public_ip"),
+					resource.TestCheckResourceAttr("cloudrift_virtual_machine.test", "status", "Active"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/virtual_machine_resource.go
+++ b/internal/provider/virtual_machine_resource.go
@@ -113,8 +113,12 @@ func (r *virtualMachineResource) ValidateConfig(ctx context.Context, req resourc
 		return
 	}
 
-	recipeSet := !config.Recipe.IsNull()
-	imageURLSet := !config.ImageUrl.IsNull()
+	// An unknown value (e.g. referencing another resource's computed output)
+	// counts as set: it isn't known yet, but it isn't absent either. Only a
+	// null or empty-string value counts as unset, matching what the client
+	// treats as "no image specified".
+	recipeSet := config.Recipe.IsUnknown() || config.Recipe.ValueString() != ""
+	imageURLSet := config.ImageUrl.IsUnknown() || config.ImageUrl.ValueString() != ""
 
 	if recipeSet == imageURLSet {
 		resp.Diagnostics.AddError(

--- a/internal/provider/virtual_machine_resource.go
+++ b/internal/provider/virtual_machine_resource.go
@@ -32,9 +32,10 @@ const (
 )
 
 var (
-	_ resource.Resource                = &virtualMachineResource{}
-	_ resource.ResourceWithConfigure   = &virtualMachineResource{}
-	_ resource.ResourceWithImportState = &virtualMachineResource{}
+	_ resource.Resource                   = &virtualMachineResource{}
+	_ resource.ResourceWithConfigure      = &virtualMachineResource{}
+	_ resource.ResourceWithImportState    = &virtualMachineResource{}
+	_ resource.ResourceWithValidateConfig = &virtualMachineResource{}
 )
 
 type virtualMachineMetadataModel struct {
@@ -68,6 +69,7 @@ type virtualMachineModel struct {
 	Name       types.String                 `tfsdk:"name"`
 	Metadata   *virtualMachineMetadataModel `tfsdk:"metadata"`
 	Recipe     types.String                 `tfsdk:"recipe"`
+	ImageUrl   types.String                 `tfsdk:"image_url"`
 	Datacenter types.String                 `tfsdk:"datacenter"`
 	SSHKeyID   types.String                 `tfsdk:"ssh_key_id"`
 }
@@ -101,6 +103,25 @@ func (r *virtualMachineResource) Configure(_ context.Context, req resource.Confi
 	}
 
 	r.client = client
+}
+
+func (r *virtualMachineResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config virtualMachineModel
+	diags := req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	recipeSet := !config.Recipe.IsNull()
+	imageURLSet := !config.ImageUrl.IsNull()
+
+	if recipeSet == imageURLSet {
+		resp.Diagnostics.AddError(
+			"Invalid Virtual Machine Configuration",
+			"Exactly one of \"recipe\" or \"image_url\" must be set.",
+		)
+	}
 }
 
 func (r *virtualMachineResource) Schema(_ context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -212,8 +233,15 @@ func (r *virtualMachineResource) Schema(_ context.Context, req resource.SchemaRe
 				},
 			},
 			"recipe": schema.StringAttribute{
-				MarkdownDescription: "The Base Image used for the Virtual Machine",
-				Required:            true,
+				MarkdownDescription: "The Base Image used for the Virtual Machine. Exactly one of `recipe` or `image_url` must be set.",
+				Optional:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"image_url": schema.StringAttribute{
+				MarkdownDescription: "Direct URL of a custom VM image to use, as an alternative to `recipe`. Exactly one of `recipe` or `image_url` must be set.",
+				Optional:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -276,6 +304,7 @@ func (r *virtualMachineResource) Create(ctx context.Context, req resource.Create
 
 	ids, err := r.client.RentPublicInstanceVM(
 		plan.Recipe.ValueString(),
+		plan.ImageUrl.ValueString(),
 		plan.Datacenter.ValueString(),
 		plan.InstanceType.ValueString(),
 		startupCommands,

--- a/internal/provider/virtual_machine_resource_test.go
+++ b/internal/provider/virtual_machine_resource_test.go
@@ -135,6 +135,7 @@ func Test_VirtualMachineResource_RecipeAndImageUrl_MutuallyExclusive(t *testing.
 	}{
 		{name: "both set", extra: `recipe = "ubuntu"` + "\n" + `image_url = "https://example.com/custom.img"`},
 		{name: "neither set", extra: ""},
+		{name: "both empty string", extra: `recipe = ""` + "\n" + `image_url = ""`},
 	}
 
 	for _, tc := range testCases {

--- a/internal/provider/virtual_machine_resource_test.go
+++ b/internal/provider/virtual_machine_resource_test.go
@@ -66,6 +66,104 @@ func Test_VirtualMachineResource_TeamId(t *testing.T) {
 	})
 }
 
+// Test_VirtualMachineResource_ImageUrl verifies that setting image_url instead
+// of recipe sends the custom image URL straight through to the rent request,
+// bypassing the recipe lookup (whose default test image_url is "test").
+func Test_VirtualMachineResource_ImageUrl(t *testing.T) {
+	t.Parallel()
+
+	keyName := "anotheruser-key"
+	publicKey := "ssh-rsa AAAA anotheruser"
+	customImageURL := "https://example.com/custom.img"
+	var capturedImageURL string
+
+	server := newVMTestServer(keyName, publicKey, func(req *http.Request) {
+		body, _ := io.ReadAll(req.Body)
+		var parsed struct {
+			Data struct {
+				Config struct {
+					VirtualMachine struct {
+						ImageUrl string `json:"image_url"`
+					} `json:"VirtualMachine"`
+				} `json:"config"`
+			} `json:"data"`
+		}
+		_ = json.Unmarshal(body, &parsed)
+		capturedImageURL = parsed.Data.Config.VirtualMachine.ImageUrl
+	})
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig(server.URL, "1.0") + fmt.Sprintf(`
+					resource "cloudrift_ssh_key" "primary" {
+					  name       = "%s"
+					  public_key = "%s"
+					}
+
+					resource "cloudrift_virtual_machine" "machine0" {
+					  image_url     = "%s"
+					  datacenter    = "us-east-nc-nr-1"
+					  instance_type = "rtx49-10c-kn.1"
+					  ssh_key_id    = cloudrift_ssh_key.primary.id
+					}
+				`, keyName, publicKey, customImageURL),
+				Check: resource.TestCheckFunc(func(s *terraform.State) error {
+					if capturedImageURL != customImageURL {
+						return fmt.Errorf("expected image_url %q in rent request, got %q", customImageURL, capturedImageURL)
+					}
+					return nil
+				}),
+			},
+		},
+	})
+}
+
+// Test_VirtualMachineResource_RecipeAndImageUrl_MutuallyExclusive verifies that
+// setting both or neither of recipe/image_url is rejected at plan time.
+func Test_VirtualMachineResource_RecipeAndImageUrl_MutuallyExclusive(t *testing.T) {
+	t.Parallel()
+
+	keyName := "anotheruser-key"
+	publicKey := "ssh-rsa AAAA anotheruser"
+	server := newVMTestServer(keyName, publicKey, nil)
+
+	testCases := []struct {
+		name  string
+		extra string
+	}{
+		{name: "both set", extra: `recipe = "ubuntu"` + "\n" + `image_url = "https://example.com/custom.img"`},
+		{name: "neither set", extra: ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resource.Test(t, resource.TestCase{
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				Steps: []resource.TestStep{
+					{
+						Config: providerConfig(server.URL, "1.0") + fmt.Sprintf(`
+							resource "cloudrift_ssh_key" "primary" {
+							  name       = "%s"
+							  public_key = "%s"
+							}
+
+							resource "cloudrift_virtual_machine" "machine0" {
+							  %s
+							  datacenter    = "us-east-nc-nr-1"
+							  instance_type = "rtx49-10c-kn.1"
+							  ssh_key_id    = cloudrift_ssh_key.primary.id
+							}
+						`, keyName, publicKey, tc.extra),
+						ExpectError: regexp.MustCompile(`(?i)exactly one of`),
+					},
+				},
+			})
+		})
+	}
+}
+
 // A freshly rented VM can be missing from the first poll (eventual consistency)
 // or briefly Inactive. Create must keep polling through that not-found rather
 // than hard-failing on it.

--- a/pkg/cloudriftapi/custom_client.go
+++ b/pkg/cloudriftapi/custom_client.go
@@ -347,9 +347,9 @@ func (c *HttpClient) TerminateInstance(id string) error {
 	return err
 }
 
-func (c *HttpClient) RentPublicInstanceVM(recipe, datacenter, instance, commands, name string, pubKeys []string) (*RentInstanceResponseProto, error) {
-	if recipe == "" {
-		return nil, errors.New("no image specified")
+func (c *HttpClient) RentPublicInstanceVM(recipe, imageURL, datacenter, instance, commands, name string, pubKeys []string) (*RentInstanceResponseProto, error) {
+	if (recipe == "") == (imageURL == "") {
+		return nil, errors.New("exactly one of recipe or image_url must be specified")
 	}
 	if len(pubKeys) == 0 || slices.Contains(pubKeys, "") {
 		return nil, errors.New("no ssh key specified")
@@ -372,10 +372,17 @@ func (c *HttpClient) RentPublicInstanceVM(recipe, datacenter, instance, commands
 		commands = strings.TrimSpace(commands)
 	}
 
-	recipe = strings.ToLower(recipe)
-	details, err := c.findVMRecipe(recipe)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find the requested recipe %s: %w", recipe, err)
+	var vmConfig InstanceConfiguration1
+	if recipe != "" {
+		recipe = strings.ToLower(recipe)
+		details, err := c.findVMRecipe(recipe)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find the requested recipe %s: %w", recipe, err)
+		}
+		vmConfig.VirtualMachine.CloudinitUrl = &details.VirtualMachine.CloudinitUrl
+		vmConfig.VirtualMachine.ImageUrl = details.VirtualMachine.ImageUrl
+	} else {
+		vmConfig.VirtualMachine.ImageUrl = imageURL
 	}
 
 	var keySelector InstanceSshKeySelector
@@ -383,9 +390,6 @@ func (c *HttpClient) RentPublicInstanceVM(recipe, datacenter, instance, commands
 		return nil, err
 	}
 
-	var vmConfig InstanceConfiguration1
-	vmConfig.VirtualMachine.CloudinitUrl = &details.VirtualMachine.CloudinitUrl
-	vmConfig.VirtualMachine.ImageUrl = details.VirtualMachine.ImageUrl
 	vmConfig.VirtualMachine.CloudinitCommands = &commands
 	vmConfig.VirtualMachine.SshKey = &keySelector
 


### PR DESCRIPTION
## Summary
- Adds an optional `image_url` attribute to `cloudrift_virtual_machine` as an alternative to `recipe`, so a VM can boot from a custom image instead of the recipe catalog.
- `recipe` and `image_url` are mutually exclusive, enforced via `ValidateConfig`.
- Client bypasses the recipe lookup entirely when `image_url` is set, sending it straight through as `config.VirtualMachine.image_url`.

Motivated by the Ubuntu 24.04 Server recipe shipping a kernel whose headers later get pruned from the Ubuntu archive, which breaks the NVIDIA GPU Operator's driver build. Manually tested against a pinned Ubuntu cloud image build and confirmed the kernel/headers version mismatch doesn't reproduce.

## Test plan
- [x] `make test` (unit tests, including new `image_url` and mutually-exclusive validation tests)
- [x] `make lint`
- [x] `make generate` and diffed the regenerated docs
- [x] Manual `terraform plan`/`apply` against a local build via `dev_overrides`, confirmed VM created with custom `image_url`
- [x] SSH'd into the resulting instance, confirmed kernel and matching `linux-headers` package are both present and installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Virtual machines can now be created using a direct image URL, including pinned Ubuntu 24.04 images.
  - Image URL and recipe configurations are supported as alternative deployment options.

- **Bug Fixes**
  - Added validation to prevent configurations where both deployment options are provided—or neither is provided.
  - Custom image URLs are now correctly passed through when provisioning virtual machines.

- **Documentation**
  - Updated virtual machine configuration guidance to describe image URL support and requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->