### PR TITLE
Let recipe accept an image URL instead of a separate image_url field

### DIFF
--- a/docs/resources/virtual_machine.md
+++ b/docs/resources/virtual_machine.md
@@ -19,14 +19,13 @@ Manage virtualMachines
 
 - `datacenter` (String) The datacenter identifier
 - `instance_type` (String) The instance type identifier
+- `recipe` (String) The Base Image used for the Virtual Machine. Either a name from the CloudRift recipe catalog (e.g. `ubuntu`), or a direct `http://` / `https://` URL of a custom VM image.
 - `ssh_key_id` (String) The SSH Key ID to be able to connect to the Virtual Machine.
 
 ### Optional
 
-- `image_url` (String) Direct URL of a custom VM image to use, as an alternative to `recipe`. Exactly one of `recipe` or `image_url` must be set.
 - `metadata` (Attributes) Option to provide metadata. Currently supported is `startup_commands`. (see [below for nested schema](#nestedatt--metadata))
 - `name` (String) Optional name for the Virtual Machine, shown in the CloudRift dashboard. Changing it forces replacement.
-- `recipe` (String) The Base Image used for the Virtual Machine. Exactly one of `recipe` or `image_url` must be set.
 
 ### Read-Only
 

--- a/internal/provider/acceptance_test.go
+++ b/internal/provider/acceptance_test.go
@@ -214,7 +214,7 @@ func TestAcc_VirtualMachineResource(t *testing.T) {
 // images end-to-end against the real API.
 const pinnedUbuntuCloudImageURL = "https://cloud-images.ubuntu.com/releases/noble/release-20260801/ubuntu-24.04-server-cloudimg-amd64.img"
 
-func TestAcc_VirtualMachineResource_ImageUrl(t *testing.T) {
+func TestAcc_VirtualMachineResource_RecipeUrl(t *testing.T) {
 	testAccPreCheck(t)
 
 	if os.Getenv("CLOUDRIFT_TEAM_ID") == "" {

--- a/internal/provider/acceptance_test.go
+++ b/internal/provider/acceptance_test.go
@@ -210,8 +210,8 @@ func TestAcc_VirtualMachineResource(t *testing.T) {
 }
 
 // pinnedUbuntuCloudImageURL is a dated (non-"current") Ubuntu 24.04 cloud
-// image build, used instead of the "recipe" catalog to test the image_url
-// attribute end-to-end against the real API.
+// image build, passed as a recipe URL instead of a catalog name to test custom
+// images end-to-end against the real API.
 const pinnedUbuntuCloudImageURL = "https://cloud-images.ubuntu.com/releases/noble/release-20260801/ubuntu-24.04-server-cloudimg-amd64.img"
 
 func TestAcc_VirtualMachineResource_ImageUrl(t *testing.T) {
@@ -249,7 +249,7 @@ func TestAcc_VirtualMachineResource_ImageUrl(t *testing.T) {
 
 					resource "cloudrift_virtual_machine" "test" {
 						name          = %q
-						image_url     = %q
+						recipe        = %q
 						datacenter    = %q
 						instance_type = %q
 						ssh_key_id    = cloudrift_ssh_key.test.id
@@ -257,7 +257,7 @@ func TestAcc_VirtualMachineResource_ImageUrl(t *testing.T) {
 				`, keyName, sshPublicKey, vmName, pinnedUbuntuCloudImageURL, instance.datacenter, instance.variantName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("cloudrift_virtual_machine.test", "name", vmName),
-					resource.TestCheckResourceAttr("cloudrift_virtual_machine.test", "image_url", pinnedUbuntuCloudImageURL),
+					resource.TestCheckResourceAttr("cloudrift_virtual_machine.test", "recipe", pinnedUbuntuCloudImageURL),
 					resource.TestCheckResourceAttrSet("cloudrift_virtual_machine.test", "id"),
 					resource.TestCheckResourceAttrSet("cloudrift_virtual_machine.test", "public_ip"),
 					resource.TestCheckResourceAttr("cloudrift_virtual_machine.test", "status", "Active"),

--- a/internal/provider/virtual_machine_resource.go
+++ b/internal/provider/virtual_machine_resource.go
@@ -69,7 +69,6 @@ type virtualMachineModel struct {
 	Name       types.String                 `tfsdk:"name"`
 	Metadata   *virtualMachineMetadataModel `tfsdk:"metadata"`
 	Recipe     types.String                 `tfsdk:"recipe"`
-	ImageUrl   types.String                 `tfsdk:"image_url"`
 	Datacenter types.String                 `tfsdk:"datacenter"`
 	SSHKeyID   types.String                 `tfsdk:"ssh_key_id"`
 }
@@ -113,17 +112,13 @@ func (r *virtualMachineResource) ValidateConfig(ctx context.Context, req resourc
 		return
 	}
 
-	// An unknown value (e.g. referencing another resource's computed output)
-	// counts as set: it isn't known yet, but it isn't absent either. Only a
-	// null or empty-string value counts as unset, matching what the client
-	// treats as "no image specified".
-	recipeSet := config.Recipe.IsUnknown() || config.Recipe.ValueString() != ""
-	imageURLSet := config.ImageUrl.IsUnknown() || config.ImageUrl.ValueString() != ""
-
-	if recipeSet == imageURLSet {
+	// Required already rejects a missing attribute, but not an explicit empty
+	// string. An unknown value (e.g. another resource's computed output) is not
+	// yet knowable, so it passes.
+	if !config.Recipe.IsUnknown() && !config.Recipe.IsNull() && config.Recipe.ValueString() == "" {
 		resp.Diagnostics.AddError(
 			"Invalid Virtual Machine Configuration",
-			"Exactly one of \"recipe\" or \"image_url\" must be set.",
+			"Attribute \"recipe\" must not be empty.",
 		)
 	}
 }
@@ -237,15 +232,8 @@ func (r *virtualMachineResource) Schema(_ context.Context, req resource.SchemaRe
 				},
 			},
 			"recipe": schema.StringAttribute{
-				MarkdownDescription: "The Base Image used for the Virtual Machine. Exactly one of `recipe` or `image_url` must be set.",
-				Optional:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-			},
-			"image_url": schema.StringAttribute{
-				MarkdownDescription: "Direct URL of a custom VM image to use, as an alternative to `recipe`. Exactly one of `recipe` or `image_url` must be set.",
-				Optional:            true,
+				MarkdownDescription: "The Base Image used for the Virtual Machine. Either a name from the CloudRift recipe catalog (e.g. `ubuntu`), or a direct `http://` / `https://` URL of a custom VM image.",
+				Required:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -308,7 +296,6 @@ func (r *virtualMachineResource) Create(ctx context.Context, req resource.Create
 
 	ids, err := r.client.RentPublicInstanceVM(
 		plan.Recipe.ValueString(),
-		plan.ImageUrl.ValueString(),
 		plan.Datacenter.ValueString(),
 		plan.InstanceType.ValueString(),
 		startupCommands,

--- a/internal/provider/virtual_machine_resource.go
+++ b/internal/provider/virtual_machine_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/berops/terraform-provider-cloudrift/pkg/cloudriftapi"
@@ -112,10 +113,10 @@ func (r *virtualMachineResource) ValidateConfig(ctx context.Context, req resourc
 		return
 	}
 
-	// Required already rejects a missing attribute, but not an explicit empty
-	// string. An unknown value (e.g. another resource's computed output) is not
-	// yet knowable, so it passes.
-	if !config.Recipe.IsUnknown() && !config.Recipe.IsNull() && config.Recipe.ValueString() == "" {
+	// Required already rejects a missing attribute, but not an explicit empty or
+	// whitespace-only string. An unknown value (e.g. another resource's computed
+	// output) is not yet knowable, so it passes.
+	if !config.Recipe.IsUnknown() && !config.Recipe.IsNull() && strings.TrimSpace(config.Recipe.ValueString()) == "" {
 		resp.Diagnostics.AddError(
 			"Invalid Virtual Machine Configuration",
 			"Attribute \"recipe\" must not be empty.",

--- a/internal/provider/virtual_machine_resource_test.go
+++ b/internal/provider/virtual_machine_resource_test.go
@@ -66,10 +66,10 @@ func Test_VirtualMachineResource_TeamId(t *testing.T) {
 	})
 }
 
-// Test_VirtualMachineResource_ImageUrl verifies that a recipe holding a URL
+// Test_VirtualMachineResource_RecipeUrl verifies that a recipe holding a URL
 // sends that URL straight through to the rent request, bypassing the recipe
 // catalog lookup (whose default test image_url is "test").
-func Test_VirtualMachineResource_ImageUrl(t *testing.T) {
+func Test_VirtualMachineResource_RecipeUrl(t *testing.T) {
 	t.Parallel()
 
 	keyName := "anotheruser-key"
@@ -121,8 +121,8 @@ func Test_VirtualMachineResource_ImageUrl(t *testing.T) {
 	})
 }
 
-// Test_VirtualMachineResource_RecipeRequired verifies that a missing or empty
-// recipe is rejected at plan time.
+// Test_VirtualMachineResource_RecipeRequired verifies that a missing, empty or
+// whitespace-only recipe is rejected at plan time.
 func Test_VirtualMachineResource_RecipeRequired(t *testing.T) {
 	t.Parallel()
 
@@ -137,6 +137,7 @@ func Test_VirtualMachineResource_RecipeRequired(t *testing.T) {
 	}{
 		{name: "not set", extra: "", errorRe: `(?i)"recipe" is required`},
 		{name: "empty string", extra: `recipe = ""`, errorRe: `(?i)"recipe" must not be empty`},
+		{name: "whitespace only", extra: `recipe = "   "`, errorRe: `(?i)"recipe" must not be empty`},
 	}
 
 	for _, tc := range testCases {

--- a/internal/provider/virtual_machine_resource_test.go
+++ b/internal/provider/virtual_machine_resource_test.go
@@ -66,15 +66,16 @@ func Test_VirtualMachineResource_TeamId(t *testing.T) {
 	})
 }
 
-// Test_VirtualMachineResource_ImageUrl verifies that setting image_url instead
-// of recipe sends the custom image URL straight through to the rent request,
-// bypassing the recipe lookup (whose default test image_url is "test").
+// Test_VirtualMachineResource_ImageUrl verifies that a recipe holding a URL
+// sends that URL straight through to the rent request, bypassing the recipe
+// catalog lookup (whose default test image_url is "test").
 func Test_VirtualMachineResource_ImageUrl(t *testing.T) {
 	t.Parallel()
 
 	keyName := "anotheruser-key"
 	publicKey := "ssh-rsa AAAA anotheruser"
-	customImageURL := "https://example.com/custom.img"
+	// Mixed case on purpose: URL paths are case-sensitive, unlike recipe names.
+	customImageURL := "https://example.com/Custom-Image.IMG"
 	var capturedImageURL string
 
 	server := newVMTestServer(keyName, publicKey, func(req *http.Request) {
@@ -103,7 +104,7 @@ func Test_VirtualMachineResource_ImageUrl(t *testing.T) {
 					}
 
 					resource "cloudrift_virtual_machine" "machine0" {
-					  image_url     = "%s"
+					  recipe        = "%s"
 					  datacenter    = "us-east-nc-nr-1"
 					  instance_type = "rtx49-10c-kn.1"
 					  ssh_key_id    = cloudrift_ssh_key.primary.id
@@ -120,9 +121,9 @@ func Test_VirtualMachineResource_ImageUrl(t *testing.T) {
 	})
 }
 
-// Test_VirtualMachineResource_RecipeAndImageUrl_MutuallyExclusive verifies that
-// setting both or neither of recipe/image_url is rejected at plan time.
-func Test_VirtualMachineResource_RecipeAndImageUrl_MutuallyExclusive(t *testing.T) {
+// Test_VirtualMachineResource_RecipeRequired verifies that a missing or empty
+// recipe is rejected at plan time.
+func Test_VirtualMachineResource_RecipeRequired(t *testing.T) {
 	t.Parallel()
 
 	keyName := "anotheruser-key"
@@ -130,12 +131,12 @@ func Test_VirtualMachineResource_RecipeAndImageUrl_MutuallyExclusive(t *testing.
 	server := newVMTestServer(keyName, publicKey, nil)
 
 	testCases := []struct {
-		name  string
-		extra string
+		name    string
+		extra   string
+		errorRe string
 	}{
-		{name: "both set", extra: `recipe = "ubuntu"` + "\n" + `image_url = "https://example.com/custom.img"`},
-		{name: "neither set", extra: ""},
-		{name: "both empty string", extra: `recipe = ""` + "\n" + `image_url = ""`},
+		{name: "not set", extra: "", errorRe: `(?i)"recipe" is required`},
+		{name: "empty string", extra: `recipe = ""`, errorRe: `(?i)"recipe" must not be empty`},
 	}
 
 	for _, tc := range testCases {
@@ -157,7 +158,7 @@ func Test_VirtualMachineResource_RecipeAndImageUrl_MutuallyExclusive(t *testing.
 							  ssh_key_id    = cloudrift_ssh_key.primary.id
 							}
 						`, keyName, publicKey, tc.extra),
-						ExpectError: regexp.MustCompile(`(?i)exactly one of`),
+						ExpectError: regexp.MustCompile(tc.errorRe),
 					},
 				},
 			})

--- a/pkg/cloudriftapi/custom_client.go
+++ b/pkg/cloudriftapi/custom_client.go
@@ -347,9 +347,15 @@ func (c *HttpClient) TerminateInstance(id string) error {
 	return err
 }
 
-func (c *HttpClient) RentPublicInstanceVM(recipe, imageURL, datacenter, instance, commands, name string, pubKeys []string) (*RentInstanceResponseProto, error) {
-	if (recipe == "") == (imageURL == "") {
-		return nil, errors.New("exactly one of recipe or image_url must be specified")
+// isImageURL reports whether a recipe value is a direct image URL rather than
+// a name from the recipe catalog.
+func isImageURL(recipe string) bool {
+	return strings.HasPrefix(recipe, "http://") || strings.HasPrefix(recipe, "https://")
+}
+
+func (c *HttpClient) RentPublicInstanceVM(recipe, datacenter, instance, commands, name string, pubKeys []string) (*RentInstanceResponseProto, error) {
+	if recipe == "" {
+		return nil, errors.New("empty recipe")
 	}
 	if len(pubKeys) == 0 || slices.Contains(pubKeys, "") {
 		return nil, errors.New("no ssh key specified")
@@ -373,7 +379,12 @@ func (c *HttpClient) RentPublicInstanceVM(recipe, imageURL, datacenter, instance
 	}
 
 	var vmConfig InstanceConfiguration1
-	if recipe != "" {
+	// A recipe is either a catalog name ("ubuntu") or a direct image URL. URLs
+	// go straight through without a catalog lookup, and are not lowercased
+	// since URL paths are case-sensitive.
+	if isImageURL(recipe) {
+		vmConfig.VirtualMachine.ImageUrl = recipe
+	} else {
 		recipe = strings.ToLower(recipe)
 		details, err := c.findVMRecipe(recipe)
 		if err != nil {
@@ -381,8 +392,6 @@ func (c *HttpClient) RentPublicInstanceVM(recipe, imageURL, datacenter, instance
 		}
 		vmConfig.VirtualMachine.CloudinitUrl = &details.VirtualMachine.CloudinitUrl
 		vmConfig.VirtualMachine.ImageUrl = details.VirtualMachine.ImageUrl
-	} else {
-		vmConfig.VirtualMachine.ImageUrl = imageURL
 	}
 
 	var keySelector InstanceSshKeySelector

--- a/pkg/cloudriftapi/custom_client.go
+++ b/pkg/cloudriftapi/custom_client.go
@@ -348,12 +348,15 @@ func (c *HttpClient) TerminateInstance(id string) error {
 }
 
 // isImageURL reports whether a recipe value is a direct image URL rather than
-// a name from the recipe catalog.
+// a name from the recipe catalog. URI schemes are case-insensitive, so the
+// scheme is matched that way while the rest of the URL is left untouched.
 func isImageURL(recipe string) bool {
-	return strings.HasPrefix(recipe, "http://") || strings.HasPrefix(recipe, "https://")
+	lower := strings.ToLower(recipe)
+	return strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://")
 }
 
 func (c *HttpClient) RentPublicInstanceVM(recipe, datacenter, instance, commands, name string, pubKeys []string) (*RentInstanceResponseProto, error) {
+	recipe = strings.TrimSpace(recipe)
 	if recipe == "" {
 		return nil, errors.New("empty recipe")
 	}

--- a/pkg/cloudriftapi/custom_client_test.go
+++ b/pkg/cloudriftapi/custom_client_test.go
@@ -1,0 +1,25 @@
+package cloudriftapi
+
+import "testing"
+
+func Test_isImageURL(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]bool{
+		"https://example.com/image.img": true,
+		"http://example.com/image.img":  true,
+		// URI schemes are case-insensitive, recipe names are not URLs.
+		"HTTPS://example.com/Image.IMG": true,
+		"Http://example.com/image.img":  true,
+		"ubuntu":                        false,
+		"ubuntu-cuda":                   false,
+		"":                              false,
+		"ftp://example.com/image.img":   false,
+	}
+
+	for input, want := range cases {
+		if got := isImageURL(input); got != want {
+			t.Errorf("isImageURL(%q) = %v, want %v", input, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #53. That PR added an `image_url` attribute alongside `recipe`, which meant two attributes for one concept plus mutual-exclusivity validation to keep them apart.

This drops `image_url`. `recipe` is required again and accepts either form:

```hcl
recipe = "ubuntu"                                   # catalog name
recipe = "https://cloud-images.ubuntu.com/....img"  # custom image
```

The client branches on prefix (`pkg/cloudriftapi/custom_client.go`):

- `http://` or `https://` sets `ImageUrl` verbatim, skips the catalog lookup, leaves `CloudinitUrl` nil.
- anything else is lowercased and looked up in the recipe catalog as before.

A bug fixed on the way: the old code lowercased `recipe` before branching, so a custom image URL with a case-sensitive path was silently corrupted. `ToLower` now only runs on catalog names, and the unit test pins this with a mixed-case URL.

Validation: `Required` covers a missing `recipe`, `ValidateConfig` rejects `recipe = ""` at plan time, and an unknown catalog name still fails loudly at apply.

**Breaking change.** `image_url` shipped in v0.2.8, so removing it means the next release is v0.3.0. Verified that existing state holding `image_url` still decodes without error (no `StateUpgrader` needed), but a VM created via `image_url` plans as a replacement since `recipe` was null in that state.

Verified with `TF_ACC=1 go test ./...`, `make lint` (0 issues), and docs regenerated. `TestAcc_VirtualMachineResource_ImageUrl` now passes the pinned Ubuntu URL through `recipe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Virtual machines now use a single `recipe` field for their base image.
  - Recipes support either CloudRift catalog image names or direct HTTP(S) image URLs.
  - Direct image URLs are accepted without catalog lookup or name normalization.

- **Breaking Changes**
  - The separate `image_url` field has been removed.
  - The `recipe` field is now required and cannot be empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->